### PR TITLE
[PR] Set the 404 page main header height to 102px

### DIFF
--- a/style.css
+++ b/style.css
@@ -256,6 +256,11 @@ figcaption.wp-caption-text {
 	color: #fff;
 	height: auto;
 }
+
+.error404 .main-header {
+	height: 102px;
+}
+
 .has-featured-image .main-header {
 	background-size: cover;
 	height: 450px;


### PR DESCRIPTION
On normal article pages without featured images, there is a cite
element that helps to extend the height of the main header. On the
404 pages, there is no cite element, so we need to manually
override things a bit.

In the future it may make more sense to define the main header at
a specific height everywhere rather than using auto
